### PR TITLE
update readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,13 +57,13 @@ kintoneのREST APIや外部APIを簡単に呼び出すユーティリティで�
 params = {"app": 123, "id": 456}
 
 # デコレータとコールバック関数を記述し、APIコールを即時実行
-@kintone_api("/k/v1/record", "GET", params)
+@kintone_api(kintone["api"]["url"]("/k/v1/records", True), "GET", params)
 def on_success(result):
     print(result)
 
 
 # 使い方2：エラー時のコールバックも含めて詳細に記述
-api_caller = kintone_api("/k/v1/record", "GET", params)
+api_caller = kintone_api(kintone["api"]["url"]("/k/v1/records", True), "GET", params)
 
 # デコレータでコールバックを定義
 @api_caller.on_success

--- a/api_document_ja.md
+++ b/api_document_ja.md
@@ -160,12 +160,12 @@ def __init__(self, api_endpoint: str, method: str, params: dict,
 **使用例:**
 ```python
 # 例1: デコレータで成功時のコールバックのみを指定して API を呼び出す 
-@kintone_api("/k/v1/records.json", "GET", {"app": 123})
+@kintone_api(kintone["api"]["url"]("/k/v1/records", True), "GET", {"app": 123})
 def handle_api_response(response):
     print("API Response:", response)
 
 # 例2: 成功時と失敗時のコールバックを指定して API を呼び出す
-event_caller = kintone_api("/k/v1/records.json", "GET", {"app": 123})
+event_caller = @kintone_api(kintone["api"]["url"]("/k/v1/records", True), "GET", {"app": 123})
 
 @event_caller.on_success
 def handle_success(response):
@@ -184,7 +184,7 @@ def handle_api_response(response):
 def handle_api_error(error):
     print("API Error:", error)
 
-api_caller = kintone_api("/k/v1/records.json", "GET", {"app": 123}, handle_api_response, handle_api_error)
+api_caller = kintone_api(kintone["api"]["url"]("/k/v1/records", True), "GET", {"app": 123}, handle_api_response, handle_api_error)
 api_caller.call()
 ```
 
@@ -223,7 +223,7 @@ def on_edit_success(event):
 @kintone_event("app.record.create.show")
 def on_create_show(event):
     # API を呼び出す
-    @kintone_api("/k/v1/records.json", "GET", {"app": 123})
+    @kintone_api(kintone["api"]["url"]("/k/v1/records", True),  "GET", {"app": 123})
     def handle_api_response(response):
         # API レスポンスを処理する
         print("API Response:", response)


### PR DESCRIPTION
This pull request includes updates to the documentation for the `kintone_api` utility to standardize the way API URLs are constructed. The primary change involves modifying the API URL construction to use the `kintone["api"]["url"]` method consistently across different examples and use cases.

Updates to documentation:

* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L60-R66): Updated the example for immediate API call execution to use `kintone["api"]["url"]("/k/v1/records", True)` for constructing the API URL.
* [`api_document_ja.md`](diffhunk://#diff-82a36ea2a9ed08452af183aaded9bd0177caa8367e3cbc5cde35849756c6a576L163-R168): Updated multiple examples to use `kintone["api"]["url"]("/k/v1/records", True)` for constructing the API URL instead of hardcoding it. [[1]](diffhunk://#diff-82a36ea2a9ed08452af183aaded9bd0177caa8367e3cbc5cde35849756c6a576L163-R168) [[2]](diffhunk://#diff-82a36ea2a9ed08452af183aaded9bd0177caa8367e3cbc5cde35849756c6a576L187-R187) [[3]](diffhunk://#diff-82a36ea2a9ed08452af183aaded9bd0177caa8367e3cbc5cde35849756c6a576L226-R226)